### PR TITLE
Make decoding 1.5x faster

### DIFF
--- a/codebook.go
+++ b/codebook.go
@@ -9,7 +9,7 @@ const codebookPattern = 0x564342 //"BCV"
 
 type codebook struct {
 	dimensions uint32
-	entries    huffmanTable
+	entries    *huffmanTable
 	values     []float32
 }
 
@@ -19,7 +19,7 @@ func (c *codebook) ReadFrom(r *bitReader) error {
 	}
 	c.dimensions = r.Read32(16)
 	numEntries := r.Read32(24)
-	c.entries = make(huffmanTable, numEntries*2-2)
+	c.entries = newHuffmanTable(numEntries*2-2)
 	ordered := r.ReadBool()
 	if !ordered {
 		sparse := r.ReadBool()

--- a/decode_test.go
+++ b/decode_test.go
@@ -80,3 +80,31 @@ decode:
 func equal(a, b, tolerance float32) bool {
 	return (a > b && a-b < tolerance) || b-a < tolerance
 }
+
+func BenchmarkDecode(b *testing.B) {
+	file, err := os.Open("testdata/test.gob")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer file.Close()
+
+	var data GobVorbis
+	if err = gob.NewDecoder(file).Decode(&data); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var dec Decoder
+		for _, header := range data.Headers {
+			if err = dec.ReadHeader(header); err != nil {
+				b.Fatal(err)
+			}
+		}
+		for _, packet := range data.Packets {
+			if _, err := dec.Decode(packet); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}

--- a/huffman.go
+++ b/huffman.go
@@ -1,11 +1,21 @@
 package vorbis
 
-type huffmanTable []uint32
+type huffmanTable struct {
+	table   []uint32
+	visited []uint32
+}
+
+func newHuffmanTable(length uint32) *huffmanTable {
+	return &huffmanTable{
+		table:   make([]uint32, length),
+		visited: make([]uint32, length),
+	}
+}
 
 func (t huffmanTable) Lookup(r *bitReader) uint32 {
 	i := uint32(0)
 	for i&0x80000000 == 0 {
-		i = t[i*2+r.Read1()]
+		i = t.table[i*2+r.Read1()]
 	}
 	return i & 0x7FFFFFFF
 }
@@ -15,37 +25,43 @@ func (t huffmanTable) Put(entry uint32, length uint8) {
 }
 
 func (t huffmanTable) put(index, entry uint32, length uint8) bool {
-	if length == 0 {
-		if t[index*2] == 0 {
-			t[index*2] = entry | 0x80000000
-			return true
-		} else if t[index*2+1] == 0 {
-			t[index*2+1] = entry | 0x80000000
-			return true
-		}
+	if length < 32 && t.visited[index]&(1<<length) != 0 {
 		return false
 	}
-	if t[index*2]&0x80000000 == 0 {
-		if t[index*2] == 0 {
-			t[index*2] = t.findEmpty(index + 1)
+	if length == 0 {
+		if t.table[index*2] == 0 {
+			t.table[index*2] = entry | 0x80000000
+			return true
 		}
-		if t.put(t[index*2], entry, length-1) {
+		if t.table[index*2+1] == 0 {
+			t.table[index*2+1] = entry | 0x80000000
+			return true
+		}
+		t.visited[index] |= 1 << length
+		return false
+	}
+	if t.table[index*2]&0x80000000 == 0 {
+		if t.table[index*2] == 0 {
+			t.table[index*2] = t.findEmpty(index + 1)
+		}
+		if t.put(t.table[index*2], entry, length-1) {
 			return true
 		}
 	}
-	if t[index*2+1]&0x80000000 == 0 {
-		if t[index*2+1] == 0 {
-			t[index*2+1] = t.findEmpty(index + 1)
+	if t.table[index*2+1]&0x80000000 == 0 {
+		if t.table[index*2+1] == 0 {
+			t.table[index*2+1] = t.findEmpty(index + 1)
 		}
-		if t.put(t[index*2+1], entry, length-1) {
+		if t.put(t.table[index*2+1], entry, length-1) {
 			return true
 		}
 	}
+	t.visited[index] |= 1 << length
 	return false
 }
 
 func (t huffmanTable) findEmpty(index uint32) uint32 {
-	for t[index*2] != 0 {
+	for t.table[index*2] != 0 {
 		index++
 	}
 	return index


### PR DESCRIPTION
I profiled this decoder and found that `huffmanTable.put` was the highest consumer of CPU. This PR adds BenchmarkDecode and introduces caching the result of visiting the Huffman tree. This makes decoding about 1.5x faster.

Before introducing caching:
```
BenchmarkDecode-4            300           5710393 ns/op
```

After introducing caching:
```
BenchmarkDecode-4            300           3960711 ns/op
```