### PR TITLE
Make imdct faster

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -51,7 +51,7 @@ func (d *Decoder) decodePacket(r *bitReader, out []float32) ([]float32, error) {
 	raw := make([][]float32, d.channels)
 	for ch := range raw {
 		raw[ch] = d.rawBuffer[ch][:blocksize]
-		imdct(d.lookup[blocktype], residueVectors[ch], raw[ch])
+		imdct(&d.lookup[blocktype], residueVectors[ch], raw[ch])
 	}
 
 	// apply window and overlap

--- a/imdct_test.go
+++ b/imdct_test.go
@@ -34,7 +34,7 @@ func TestIMDCT(t *testing.T) {
 	var lookup imdctLookup
 	generateIMDCTLookup(blocksize, &lookup)
 	result := make([]float32, blocksize)
-	imdct(lookup, data, result)
+	imdct(&lookup, data, result)
 
 	for i := range result {
 		if !equalRel(result[i], reference[i], 1.002) {
@@ -63,7 +63,7 @@ func BenchmarkIMDCT(b *testing.B) {
 		// the imdct function does not preserve the input,
 		// reset it, otherwise everything ends up being NaN
 		copy(in, data)
-		imdct(lookup, in, out)
+		imdct(&lookup, in, out)
 	}
 }
 


### PR DESCRIPTION
This PR makes imdct faster and decoding a little faster.

Before this PR (on MacBook Pro 2015):

```
$ go test -bench=Bench
BenchmarkSetup-4            1000           1280923 ns/op
BenchmarkDecode-4           1000           2063860 ns/op
BenchmarkIMDCT-4           10000            112480 ns/op
PASS
ok      github.com/jfreymuth/vorbis     4.854s
```

After this PR:

```
$ go test -bench=Bench
BenchmarkSetup-4            1000           1270706 ns/op
BenchmarkDecode-4           1000           1886631 ns/op
BenchmarkIMDCT-4           20000             92588 ns/op
PASS
ok      github.com/jfreymuth/vorbis     6.298s
```
