### PR TITLE
Reduce memory allocations by caching at decodePacket

### DIFF
--- a/vorbis.go
+++ b/vorbis.go
@@ -27,6 +27,10 @@ type Decoder struct {
 	lookup        [2]imdctLookup
 	residueBuffer [][]float32
 	rawBuffer     [][]float32
+
+	floorData      []floorData
+	residueVectors [][]float32
+	raw            [][]float32
 }
 
 // The Bitrate of a vorbis stream.


### PR DESCRIPTION
This can be a significant locations to invoke `runtime.mallocgc`.

On browsers:

![image](https://user-images.githubusercontent.com/16950/105723246-eac64800-5f69-11eb-9bba-465fc30846f6.png)
