### PR TITLE
optimize residual decoding routines

### DIFF
--- a/bitreader.go
+++ b/bitreader.go
@@ -1,75 +1,69 @@
 package vorbis
 
 type bitReader struct {
-	data      []byte
-	position  int
-	bitOffset uint
-	eof       bool
+	data     []byte
+	position int
+	buf      uint64
+	bitsLeft uint
+	eof      bool
 }
 
 func newBitReader(data []byte) *bitReader {
-	return &bitReader{data, 0, 0, false}
+	return &bitReader{data: data}
 }
 
 func (r *bitReader) EOF() bool {
 	return r.eof
 }
 
-func (r *bitReader) Read1() uint32 {
-	if r.position >= len(r.data) {
-		r.eof = true
-		return 0
-	}
-	var result uint32
-	if r.data[r.position]&(1<<r.bitOffset) != 0 {
-		result = 1
-	}
-	if r.bitOffset < 7 {
-		r.bitOffset++
-	} else {
-		r.bitOffset = 0
+func (r *bitReader) refill() {
+	for r.bitsLeft <= 56 && r.position < len(r.data) {
+		r.buf |= uint64(r.data[r.position]) << r.bitsLeft
+		r.bitsLeft += 8
 		r.position++
 	}
-	return result
 }
 
-func (r *bitReader) read(n uint, bits uint) uint32 {
-	if n > bits {
-		panic("invalid argument")
-	}
-	var result uint32
-	var written uint
-	size := n
-	for n > 0 {
-		if r.position >= len(r.data) {
+func (r *bitReader) Read1() uint32 {
+	if r.bitsLeft == 0 {
+		r.refill()
+		if r.bitsLeft == 0 {
 			r.eof = true
 			return 0
 		}
-		result |= uint32(r.data[r.position]>>r.bitOffset) << written
-		written += 8 - r.bitOffset
-		if n < 8-r.bitOffset {
-			r.bitOffset += n
-			break
-		}
-		n -= 8 - r.bitOffset
-		r.bitOffset = 0
-		r.position++
 	}
-	return result &^ (0xFFFFFFFF << size)
+	bit := uint32(r.buf & 1)
+	r.buf >>= 1
+	r.bitsLeft--
+	return bit
+}
+
+func (r *bitReader) read(n uint) uint32 {
+	if r.bitsLeft < n {
+		r.refill()
+		if r.bitsLeft < n {
+			r.eof = true
+			return 0
+		}
+	}
+	val := uint32(r.buf & ((1 << n) - 1))
+	r.buf >>= n
+	r.bitsLeft -= n
+	return val
 }
 
 func (r *bitReader) Read8(n uint) uint8 {
-	return uint8(r.read(n, 8))
+	return uint8(r.read(n))
 }
 
 func (r *bitReader) Read16(n uint) uint16 {
-	return uint16(r.read(n, 16))
+	return uint16(r.read(n))
 }
 
 func (r *bitReader) Read32(n uint) uint32 {
-	return uint32(r.read(n, 32))
+	return r.read(n)
 }
 
 func (r *bitReader) ReadBool() bool {
-	return r.Read8(1) == 1
+	return r.Read1() == 1
 }

--- a/codebook.go
+++ b/codebook.go
@@ -9,7 +9,7 @@ const codebookPattern = 0x564342 //"BCV"
 
 type codebook struct {
 	dimensions uint32
-	entries    huffmanCode
+	entries    *huffmanCode
 	values     []float32
 }
 
@@ -40,7 +40,7 @@ func (c *codebook) ReadFrom(r *bitReader) error {
 			currentLength++
 		}
 	}
-	c.entries = entries.code
+	c.entries = entries.build()
 
 	lookupType := r.Read8(4)
 	if lookupType == 0 {

--- a/huffman.go
+++ b/huffman.go
@@ -1,23 +1,38 @@
 package vorbis
 
-type huffmanCode []uint32
+type huffmanCode struct {
+	tree  []uint32
+	table [256]uint32 // (value<<5)|length, 0 = fallback to tree
+}
 
-func (h huffmanCode) Lookup(r *bitReader) uint32 {
+func (h *huffmanCode) Lookup(r *bitReader) uint32 {
+	if r.bitsLeft < 8 {
+		r.refill()
+	}
+	if r.bitsLeft >= 8 {
+		entry := h.table[uint8(r.buf)]
+		if entry != 0 {
+			r.buf >>= entry & 0x1f
+			r.bitsLeft -= uint(entry & 0x1f)
+			return entry >> 5
+		}
+	}
+	// fallback: tree walk for codes longer than 8 bits
 	i := uint32(0)
 	for i&1 == 0 {
-		i = h[i+r.Read1()]
+		i = h.tree[i+r.Read1()]
 	}
 	return i >> 1
 }
 
 type huffmanBuilder struct {
-	code      huffmanCode
+	tree      []uint32
 	minLength []uint8
 }
 
 func newHuffmanBuilder(size uint32) *huffmanBuilder {
 	return &huffmanBuilder{
-		code:      make(huffmanCode, size),
+		tree:      make([]uint32, size),
 		minLength: make([]uint8, size/2),
 	}
 }
@@ -31,31 +46,31 @@ func (t *huffmanBuilder) put(index, entry uint32, length uint8) bool {
 		return false
 	}
 	if length == 0 {
-		if t.code[index] == 0 {
-			t.code[index] = entry*2 + 1
+		if t.tree[index] == 0 {
+			t.tree[index] = entry*2 + 1
 			return true
 		}
-		if t.code[index+1] == 0 {
-			t.code[index+1] = entry*2 + 1
+		if t.tree[index+1] == 0 {
+			t.tree[index+1] = entry*2 + 1
 			t.minLength[index/2] = 1
 			return true
 		}
 		t.minLength[index/2] = 1
 		return false
 	}
-	if t.code[index]&1 == 0 {
-		if t.code[index] == 0 {
-			t.code[index] = t.findEmpty(index + 2)
+	if t.tree[index]&1 == 0 {
+		if t.tree[index] == 0 {
+			t.tree[index] = t.findEmpty(index + 2)
 		}
-		if t.put(t.code[index], entry, length-1) {
+		if t.put(t.tree[index], entry, length-1) {
 			return true
 		}
 	}
-	if t.code[index+1]&1 == 0 {
-		if t.code[index+1] == 0 {
-			t.code[index+1] = t.findEmpty(index + 2)
+	if t.tree[index+1]&1 == 0 {
+		if t.tree[index+1] == 0 {
+			t.tree[index+1] = t.findEmpty(index + 2)
 		}
-		if t.put(t.code[index+1], entry, length-1) {
+		if t.put(t.tree[index+1], entry, length-1) {
 			return true
 		}
 	}
@@ -64,8 +79,30 @@ func (t *huffmanBuilder) put(index, entry uint32, length uint8) bool {
 }
 
 func (t *huffmanBuilder) findEmpty(index uint32) uint32 {
-	for t.code[index] != 0 {
+	for t.tree[index] != 0 {
 		index += 2
 	}
 	return index
+}
+
+func (t *huffmanBuilder) build() *huffmanCode {
+	h := &huffmanCode{tree: t.tree}
+	for bits := 0; bits < 256; bits++ {
+		i := uint32(0)
+		b := uint32(bits)
+		for consumed := uint32(1); consumed <= 8; consumed++ {
+			next := h.tree[i+b&1]
+			b >>= 1
+			if next&1 != 0 {
+				// leaf: pack (value<<5)|length, guaranteed non-zero since consumed>=1
+				h.table[bits] = (next>>1)<<5 | consumed
+				break
+			}
+			if next == 0 {
+				break // incomplete tree branch
+			}
+			i = next
+		}
+	}
+	return h
 }

--- a/huffman.go
+++ b/huffman.go
@@ -2,7 +2,7 @@ package vorbis
 
 type huffmanCode struct {
 	tree  []uint32
-	table [256]uint32 // (value<<5)|length, 0 = fallback to tree
+	table [256]uint32 // (value<<4)|length, 0 = fallback to tree
 }
 
 func (h *huffmanCode) Lookup(r *bitReader) uint32 {
@@ -12,9 +12,9 @@ func (h *huffmanCode) Lookup(r *bitReader) uint32 {
 	if r.bitsLeft >= 8 {
 		entry := h.table[uint8(r.buf)]
 		if entry != 0 {
-			r.buf >>= entry & 0x1f
-			r.bitsLeft -= uint(entry & 0x1f)
-			return entry >> 5
+			r.buf >>= entry & 0xf
+			r.bitsLeft -= uint(entry & 0xf)
+			return entry >> 4
 		}
 	}
 	// fallback: tree walk for codes longer than 8 bits
@@ -94,8 +94,8 @@ func (t *huffmanBuilder) build() *huffmanCode {
 			next := h.tree[i+b&1]
 			b >>= 1
 			if next&1 != 0 {
-				// leaf: pack (value<<5)|length, guaranteed non-zero since consumed>=1
-				h.table[bits] = (next>>1)<<5 | consumed
+				// leaf: pack (value<<4)|length, guaranteed non-zero since consumed>=1
+				h.table[bits] = (next>>1)<<4 | consumed
 				break
 			}
 			if next == 0 {


### PR DESCRIPTION
- Use a 64-bit buffer for bitReader, better utilizing branch prediction for an 1-8% increase in performance in both setup and decoding
- precompute a table with the most common huffman codes. This slows down your BenchmarkSetup significantly, but it makes loading long music files MUCH faster (my game loaded 26 ogg tracks from multiple sources in 6s originally. with this change, it went down to 5s, so a solid 20% boost)